### PR TITLE
Add Anthropic provider

### DIFF
--- a/src/media/providers/README.md
+++ b/src/media/providers/README.md
@@ -12,6 +12,11 @@ providers/
 │   ├── OpenRouterAPIClient.ts          # API communication
 │   ├── OpenRouterProvider.test.ts      # Tests
 │   └── index.ts                        # Clean exports
+├── anthropic/                 # Everything Anthropic Claude
+│   ├── AnthropicProvider.ts            # Service management & factory
+│   ├── AnthropicTextToTextModel.ts     # Model implementations
+│   ├── AnthropicAPIClient.ts           # API communication
+│   └── index.ts                        # Clean exports
 ├── replicate/                  # Everything Replicate
 │   ├── ReplicateProvider.ts
 │   ├── ReplicateTextToImageModel.ts

--- a/src/media/providers/anthropic/AnthropicAPIClient.ts
+++ b/src/media/providers/anthropic/AnthropicAPIClient.ts
@@ -1,0 +1,117 @@
+/**
+ * Anthropic API Client
+ *
+ * Minimal client for interacting with Anthropic's Claude API.
+ */
+
+import axios, { AxiosInstance, AxiosResponse } from 'axios';
+
+export interface AnthropicConfig {
+  apiKey: string;
+  baseUrl?: string;
+  timeout?: number;
+}
+
+export interface AnthropicMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+export interface AnthropicChatRequest {
+  model: string;
+  max_tokens: number;
+  messages: AnthropicMessage[];
+  temperature?: number;
+  top_p?: number;
+  stop_sequences?: string[];
+  system?: string;
+  stream?: boolean;
+}
+
+export interface AnthropicChatResponse {
+  id: string;
+  type: string;
+  role: string;
+  content: Array<{ type: string; text: string }>;
+  model: string;
+  stop_reason: string | null;
+  stop_sequence: string | null;
+}
+
+export interface AnthropicModel {
+  id: string;
+  input_tokens?: number;
+  output_tokens?: number;
+}
+
+export interface AnthropicModelsResponse {
+  data: AnthropicModel[];
+}
+
+export class AnthropicAPIClient {
+  private client: AxiosInstance;
+  private config: AnthropicConfig;
+
+  constructor(config: AnthropicConfig) {
+    this.config = {
+      baseUrl: 'https://api.anthropic.com/v1',
+      timeout: 300000,
+      ...config
+    };
+
+    this.client = axios.create({
+      baseURL: this.config.baseUrl,
+      timeout: this.config.timeout,
+      headers: {
+        'x-api-key': this.config.apiKey,
+        'anthropic-version': '2023-06-01',
+        'content-type': 'application/json'
+      }
+    });
+  }
+
+  async testConnection(): Promise<boolean> {
+    try {
+      await this.client.get('/models');
+      return true;
+    } catch (error) {
+      console.warn('Anthropic connection test failed:', error);
+      return false;
+    }
+  }
+
+  async getAvailableModels(): Promise<AnthropicModel[]> {
+    try {
+      const response: AxiosResponse<AnthropicModelsResponse> = await this.client.get('/models');
+      return response.data.data;
+    } catch (error) {
+      throw new Error(`Failed to fetch Anthropic models: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  }
+
+  async generateText(model: string, prompt: string, options?: { temperature?: number; maxTokens?: number; topP?: number; systemPrompt?: string }): Promise<string> {
+    const messages: AnthropicMessage[] = [];
+
+    if (options?.systemPrompt) {
+      messages.push({ role: 'system', content: options.systemPrompt });
+    }
+
+    messages.push({ role: 'user', content: prompt });
+
+    const request: AnthropicChatRequest = {
+      model,
+      max_tokens: options?.maxTokens ?? 1024,
+      messages,
+      temperature: options?.temperature,
+      top_p: options?.topP
+    };
+
+    const response: AxiosResponse<AnthropicChatResponse> = await this.client.post('/messages', request);
+
+    if (!response.data || !response.data.content || response.data.content.length === 0) {
+      throw new Error('No response content returned from Anthropic');
+    }
+
+    return response.data.content.map(part => part.text).join('');
+  }
+}

--- a/src/media/providers/anthropic/AnthropicProvider.ts
+++ b/src/media/providers/anthropic/AnthropicProvider.ts
@@ -1,0 +1,222 @@
+/**
+ * Anthropic Provider with TextToText Support
+ *
+ * Provider that integrates with Anthropic's Claude API.
+ */
+
+import {
+  MediaProvider,
+  ProviderType,
+  MediaCapability,
+  ProviderModel,
+  ProviderConfig,
+  GenerationRequest,
+  GenerationResult
+} from '../../types/provider';
+import { AnthropicAPIClient, AnthropicConfig } from './AnthropicAPIClient';
+import { TextToTextProvider } from '../../capabilities';
+import { TextToTextModel } from '../../models/abstracts/TextToTextModel';
+import { AnthropicTextToTextModel } from './AnthropicTextToTextModel';
+
+export class AnthropicProvider implements MediaProvider, TextToTextProvider {
+  readonly id = 'anthropic';
+  readonly name = 'Anthropic';
+  readonly type = ProviderType.REMOTE;
+  readonly capabilities = [MediaCapability.TEXT_TO_TEXT, MediaCapability.TEXT_TO_TEXT];
+
+  private config?: ProviderConfig;
+  private apiClient?: AnthropicAPIClient;
+  private discoveredModels = new Map<string, ProviderModel>();
+  private configurationPromise: Promise<void> | null = null;
+
+  constructor() {
+    this.configurationPromise = this.autoConfigureFromEnv().catch(() => {
+      this.configurationPromise = null;
+    });
+  }
+
+  get models(): ProviderModel[] {
+    return Array.from(this.discoveredModels.values());
+  }
+
+  async configure(config: ProviderConfig): Promise<void> {
+    this.config = config;
+
+    if (!config.apiKey) {
+      throw new Error('Anthropic API key is required');
+    }
+
+    const anthropicConfig: AnthropicConfig = {
+      apiKey: config.apiKey,
+      baseUrl: config.baseUrl,
+      timeout: config.timeout
+    };
+
+    this.apiClient = new AnthropicAPIClient(anthropicConfig);
+
+    await this.discoverModels();
+  }
+
+  async isAvailable(): Promise<boolean> {
+    if (!this.apiClient) {
+      return false;
+    }
+
+    try {
+      return await this.apiClient.testConnection();
+    } catch (error) {
+      console.warn('Anthropic availability check failed:', error);
+      return false;
+    }
+  }
+
+  getModelsForCapability(capability: MediaCapability): ProviderModel[] {
+    if (capability === MediaCapability.TEXT_TO_TEXT) {
+      return this.models;
+    }
+    return [];
+  }
+
+  async getHealth() {
+    const isAvailable = await this.isAvailable();
+
+    return {
+      status: isAvailable ? 'healthy' as const : 'unhealthy' as const,
+      uptime: process.uptime(),
+      activeJobs: 0,
+      queuedJobs: 0,
+      lastError: isAvailable ? undefined : 'API connection failed'
+    };
+  }
+
+  async createTextToTextModel(modelId: string): Promise<TextToTextModel> {
+    if (!this.apiClient) {
+      throw new Error('Provider not configured');
+    }
+
+    if (!this.supportsTextToTextModel(modelId)) {
+      throw new Error(`Model '${modelId}' is not supported by Anthropic provider`);
+    }
+
+    return new AnthropicTextToTextModel({ apiClient: this.apiClient, modelId });
+  }
+
+  async getModel(modelId: string): Promise<any> {
+    if (!this.apiClient) {
+      await this.ensureConfigured();
+    }
+
+    await this.ensureModelsDiscovered();
+
+    return this.createTextToTextModel(modelId);
+  }
+
+  supportsTextToTextModel(modelId: string): boolean {
+    return this.discoveredModels.has(modelId);
+  }
+
+  private async discoverModels(): Promise<void> {
+    if (!this.apiClient) return;
+
+    try {
+      const models = await this.apiClient.getAvailableModels();
+
+      if (!models || models.length === 0) {
+        this.populateDefaultModels();
+        return;
+      }
+
+      models.forEach(model => {
+        const providerModel: ProviderModel = {
+          id: model.id,
+          name: model.id,
+          description: `Anthropic model: ${model.id}`,
+          capabilities: [MediaCapability.TEXT_TO_TEXT, MediaCapability.TEXT_TO_TEXT],
+          parameters: {
+            temperature: { type: 'number', min: 0, max: 1, default: 0.7 },
+            max_tokens: { type: 'number', min: 1, max: 4096, default: 1024 },
+            top_p: { type: 'number', min: 0, max: 1, default: 1 }
+          }
+        };
+        this.discoveredModels.set(model.id, providerModel);
+      });
+    } catch (error) {
+      console.warn('[AnthropicProvider] Model discovery failed, using static list:', error);
+      this.populateDefaultModels();
+    }
+  }
+
+  private populateDefaultModels() {
+    const modelIds = [
+      'claude-3-7-sonnet-latest',
+      'claude-3-7-sonnet-20250219',
+      'claude-3-5-haiku-latest',
+      'claude-3-5-haiku-20241022',
+      'claude-sonnet-4-20250514',
+      'claude-sonnet-4-0',
+      'claude-4-sonnet-20250514',
+      'claude-3-5-sonnet-latest',
+      'claude-3-5-sonnet-20241022',
+      'claude-3-5-sonnet-20240620',
+      'claude-opus-4-0',
+      'claude-opus-4-20250514',
+      'claude-4-opus-20250514',
+      'claude-3-opus-latest',
+      'claude-3-opus-20240229',
+      'claude-3-sonnet-20240229',
+      'claude-3-haiku-20240307',
+      'claude-2.1',
+      'claude-2.0'
+    ];
+
+    modelIds.forEach(id => {
+      const providerModel: ProviderModel = {
+        id,
+        name: id,
+        description: `Anthropic model: ${id}`,
+        capabilities: [MediaCapability.TEXT_TO_TEXT, MediaCapability.TEXT_TO_TEXT],
+        parameters: {
+          temperature: { type: 'number', min: 0, max: 1, default: 0.7 },
+          max_tokens: { type: 'number', min: 1, max: 4096, default: 1024 },
+          top_p: { type: 'number', min: 0, max: 1, default: 1 }
+        }
+      };
+      this.discoveredModels.set(id, providerModel);
+    });
+  }
+
+  private async autoConfigureFromEnv(): Promise<void> {
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+
+    if (apiKey) {
+      await this.configure({ apiKey, timeout: 300000, retries: 3 });
+    } else {
+      throw new Error('No ANTHROPIC_API_KEY found in environment');
+    }
+  }
+
+  private async ensureConfigured(): Promise<void> {
+    if (this.apiClient) return;
+
+    if (this.configurationPromise) {
+      await this.configurationPromise;
+    }
+
+    if (!this.apiClient) {
+      throw new Error('Provider auto-configuration failed - no API key found');
+    }
+  }
+
+  private async ensureModelsDiscovered(): Promise<void> {
+    if (this.discoveredModels.size > 0) return;
+
+    if (!this.apiClient) {
+      await this.ensureConfigured();
+    }
+
+    await this.discoverModels();
+  }
+}
+
+import { ProviderRegistry } from '../../registry/ProviderRegistry';
+ProviderRegistry.getInstance().register('anthropic', AnthropicProvider);

--- a/src/media/providers/anthropic/AnthropicTextToTextModel.ts
+++ b/src/media/providers/anthropic/AnthropicTextToTextModel.ts
@@ -1,0 +1,88 @@
+/**
+ * Anthropic Text-to-Text Model
+ *
+ * Concrete implementation of TextToTextModel for Anthropic's Claude models.
+ */
+
+import { TextToTextModel, TextToTextOptions } from '../../models/abstracts/TextToTextModel';
+import { ModelMetadata } from '../../models/abstracts/Model';
+import { Text, TextRole } from '../../assets/roles';
+import { AnthropicAPIClient } from './AnthropicAPIClient';
+import { createGenerationPrompt } from '../../utils/GenerationPromptHelper';
+
+export interface AnthropicTextToTextOptions extends TextToTextOptions {
+  systemPrompt?: string;
+}
+
+export interface AnthropicTextToTextConfig {
+  apiClient: AnthropicAPIClient;
+  modelId: string;
+  metadata?: Partial<ModelMetadata>;
+}
+
+export class AnthropicTextToTextModel extends TextToTextModel {
+  private apiClient: AnthropicAPIClient;
+  private modelId: string;
+
+  constructor(config: AnthropicTextToTextConfig) {
+    const metadata: ModelMetadata = {
+      id: config.modelId,
+      name: config.metadata?.name || `Anthropic ${config.modelId}`,
+      description: config.metadata?.description || `Anthropic text-to-text model: ${config.modelId}`,
+      version: config.metadata?.version || '1.0.0',
+      provider: 'anthropic',
+      capabilities: ['text-generation'],
+      inputTypes: ['text'],
+      outputTypes: ['text'],
+      ...config.metadata
+    };
+
+    super(metadata);
+    this.apiClient = config.apiClient;
+    this.modelId = config.modelId;
+  }
+
+  async transform(input: TextRole | TextRole[], options?: AnthropicTextToTextOptions): Promise<Text> {
+    const startTime = Date.now();
+
+    const inputRole = Array.isArray(input) ? input[0] : input;
+    const text = await inputRole.asText();
+
+    if (!text.isValid()) {
+      throw new Error('Invalid text data provided');
+    }
+
+    const generated = await this.apiClient.generateText(this.modelId, text.content, {
+      temperature: options?.temperature,
+      maxTokens: options?.maxOutputTokens,
+      topP: options?.topP,
+      systemPrompt: options?.systemPrompt
+    });
+
+    const processingTime = Date.now() - startTime;
+
+    return new Text(generated, text.language || 'auto', 1.0, {
+      processingTime,
+      model: this.modelId,
+      provider: 'anthropic',
+      generation_prompt: createGenerationPrompt({
+        input,
+        options,
+        modelId: this.modelId,
+        modelName: this.modelId,
+        provider: 'anthropic',
+        transformationType: 'text-to-text',
+        processingTime
+      })
+    }, text.sourceAsset);
+  }
+
+  async isAvailable(): Promise<boolean> {
+    try {
+      return await this.apiClient.testConnection();
+    } catch (error) {
+      console.warn(`Anthropic model ${this.modelId} availability check failed:`, error);
+      return false;
+    }
+  }
+}

--- a/src/media/providers/anthropic/index.ts
+++ b/src/media/providers/anthropic/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Anthropic Provider - Complete Integration Package
+ *
+ * All Anthropic-related components in one place:
+ * - Provider (service management & model factory)
+ * - Model (text generation)
+ * - Client (API communication)
+ */
+
+export { AnthropicProvider } from './AnthropicProvider';
+export { AnthropicTextToTextModel } from './AnthropicTextToTextModel';
+export type { AnthropicTextToTextOptions, AnthropicTextToTextConfig } from './AnthropicTextToTextModel';
+export { AnthropicAPIClient } from './AnthropicAPIClient';
+export type { AnthropicConfig } from './AnthropicAPIClient';

--- a/src/media/providers/index.ts
+++ b/src/media/providers/index.ts
@@ -8,6 +8,9 @@
 // OpenRouter Provider Package
 export * from './openrouter';
 
+// Anthropic Provider Package
+export * from './anthropic';
+
 // Replicate Provider Package  
 export * from './replicate';
 

--- a/src/media/registry/bootstrap.ts
+++ b/src/media/registry/bootstrap.ts
@@ -32,6 +32,7 @@ export async function initializeProviders(): Promise<void> {
     () => import('../providers/together/TogetherProvider'),
     () => import('../providers/replicate/ReplicateProvider'),
     () => import('../providers/openrouter/OpenRouterProvider'),
+    () => import('../providers/anthropic/AnthropicProvider'),
     () => import('../providers/docker/ffmpeg/FFMPEGDockerProvider'),
     () => import('../providers/docker/chatterbox/ChatterboxDockerProvider'),
     () => import('../providers/docker/whisper/WhisperDockerProvider'),


### PR DESCRIPTION
## Summary
- implement Anthropic provider with Claude models
- expose Anthropic provider in provider index and bootstrap
- document the provider in README

## Testing
- `npx vitest run` *(fails: Cannot find module 'vitest/config')*

------
https://chatgpt.com/codex/tasks/task_e_6859c7d5e308832f9a91f64d7a5293ea

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Anthropic Claude as a new provider for text generation.
  - Users can now select Anthropic Claude models for text-to-text tasks.
  - Anthropic provider is automatically available and configurable alongside existing providers.

- **Documentation**
  - Updated documentation to describe the new Anthropic Claude provider and its integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->