### PR TITLE
Fix bootstrap to register OpenAI provider

### DIFF
--- a/src/media/registry/bootstrap.ts
+++ b/src/media/registry/bootstrap.ts
@@ -32,6 +32,7 @@ export async function initializeProviders(): Promise<void> {
     () => import('../providers/together/TogetherProvider'),
     () => import('../providers/replicate/ReplicateProvider'),
     () => import('../providers/openrouter/OpenRouterProvider'),
+    () => import('../providers/openai/OpenAIProvider'),
     () => import('../providers/anthropic/AnthropicProvider'),
     () => import('../providers/docker/ffmpeg/FFMPEGDockerProvider'),
     () => import('../providers/docker/chatterbox/ChatterboxDockerProvider'),


### PR DESCRIPTION
## Summary
- add OpenAI provider to provider bootstrap list

## Testing
- `npm test` *(fails: WhisperAPIClient tests and others due to missing environment)*

------
https://chatgpt.com/codex/tasks/task_e_6859cc7bc718832fb045f22ec64c14ca

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the OpenAI provider, enabling its use alongside other available providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->