### PR TITLE
Add Ollama docker provider

### DIFF
--- a/services/ollama/docker-compose.yml
+++ b/services/ollama/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  ollama:
+    image: ollama/ollama:latest
+    container_name: ollama-service
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:11434/api/tags"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+
+volumes:
+  ollama_data:
+    driver: local

--- a/src/media/models/index.ts
+++ b/src/media/models/index.ts
@@ -43,6 +43,7 @@ export { WhisperDockerModel } from '../providers/docker/whisper/WhisperDockerMod
 
 export { FFMPEGDockerModel } from '../providers/docker/ffmpeg/FFMPEGDockerModel';
 export { FFMPEGVideoFilterModel } from '../providers/docker/ffmpeg/FFMPEGVideoFilterModel';
+export { OllamaTextToTextModel } from '../providers/docker/ollama/OllamaTextToTextModel';
 
 // Core media types (now properly organized in shared/)
 export { Audio, Video, Text, Image } from '@/media/assets/roles';

--- a/src/media/providers/docker/ollama/OllamaAPIClient.ts
+++ b/src/media/providers/docker/ollama/OllamaAPIClient.ts
@@ -1,0 +1,56 @@
+import axios, { AxiosInstance } from 'axios';
+
+export interface OllamaConfig {
+  baseUrl?: string;
+  timeout?: number;
+}
+
+export interface OllamaGenerateRequest {
+  model: string;
+  prompt: string;
+  stream?: boolean;
+}
+
+export interface OllamaGenerateResponse {
+  response: string;
+  model: string;
+}
+
+export class OllamaAPIClient {
+  private client: AxiosInstance;
+  private config: Required<OllamaConfig>;
+
+  constructor(config: OllamaConfig = {}) {
+    this.config = {
+      baseUrl: config.baseUrl || 'http://localhost:11434',
+      timeout: config.timeout || 300000,
+    };
+
+    this.client = axios.create({
+      baseURL: this.config.baseUrl,
+      timeout: this.config.timeout,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  async testConnection(): Promise<boolean> {
+    try {
+      await this.client.get('/api/tags');
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async generateText(request: OllamaGenerateRequest): Promise<OllamaGenerateResponse> {
+    const { data } = await this.client.post('/api/generate', {
+      model: request.model,
+      prompt: request.prompt,
+      stream: request.stream ?? false,
+    });
+    if (!data || typeof data.response !== 'string') {
+      throw new Error('Invalid response from Ollama');
+    }
+    return { response: data.response, model: data.model || request.model };
+  }
+}

--- a/src/media/providers/docker/ollama/OllamaDockerProvider.ts
+++ b/src/media/providers/docker/ollama/OllamaDockerProvider.ts
@@ -1,0 +1,120 @@
+import {
+  MediaProvider,
+  ProviderType,
+  MediaCapability,
+  ProviderModel,
+  ProviderConfig,
+} from '../../../types/provider';
+import { OllamaDockerService } from '../../../services/OllamaDockerService';
+import { OllamaAPIClient } from './OllamaAPIClient';
+import { TextToTextProvider } from '../../../capabilities';
+import { TextToTextModel } from '../../../models/abstracts/TextToTextModel';
+import { OllamaTextToTextModel } from './OllamaTextToTextModel';
+
+export class OllamaDockerProvider implements MediaProvider, TextToTextProvider {
+  readonly id = 'ollama-docker';
+  readonly name = 'Ollama Docker Provider';
+  readonly type = ProviderType.LOCAL;
+  readonly capabilities = [MediaCapability.TEXT_TO_TEXT];
+  readonly models: ProviderModel[] = [];
+
+  private dockerService?: OllamaDockerService;
+  private apiClient?: OllamaAPIClient;
+
+  protected async getDockerService(): Promise<OllamaDockerService> {
+    if (!this.dockerService) {
+      this.dockerService = new OllamaDockerService();
+    }
+    return this.dockerService;
+  }
+
+  protected async getAPIClient(): Promise<OllamaAPIClient> {
+    if (!this.apiClient) {
+      this.apiClient = new OllamaAPIClient();
+    }
+    return this.apiClient;
+  }
+
+  async startService(): Promise<boolean> {
+    const svc = await this.getDockerService();
+    const started = await svc.startService();
+    if (started) {
+      return svc.waitForHealthy(30000);
+    }
+    return false;
+  }
+
+  async stopService(): Promise<boolean> {
+    const svc = await this.getDockerService();
+    return svc.stopService();
+  }
+
+  async getServiceStatus(): Promise<{ running: boolean; healthy: boolean; error?: string }> {
+    try {
+      const status = await (await this.getDockerService()).getServiceStatus();
+      return { running: status.running, healthy: status.health === 'healthy' };
+    } catch (error) {
+      return { running: false, healthy: false, error: (error as Error).message };
+    }
+  }
+
+  getAvailableModels(): string[] {
+    return ['llama2', 'llama3', 'mistral', 'phi'];
+  }
+
+  supportsTextToTextModel(modelId: string): boolean {
+    return typeof modelId === 'string' && modelId.length > 0;
+  }
+
+  getSupportedTextToTextModels(): string[] {
+    return this.getAvailableModels();
+  }
+
+  async createTextToTextModel(modelId: string): Promise<TextToTextModel> {
+    const apiClient = await this.getAPIClient();
+    return new OllamaTextToTextModel({ apiClient, modelId });
+  }
+
+  async isAvailable(): Promise<boolean> {
+    const svc = await this.getDockerService();
+    return svc.isHealthy();
+  }
+
+  getModelsForCapability(capability: MediaCapability): ProviderModel[] {
+    if (capability === MediaCapability.TEXT_TO_TEXT) {
+      return this.getAvailableModels().map(id => ({
+        id,
+        name: `Ollama ${id}`,
+        description: `Local Ollama model: ${id}`,
+        capabilities: [MediaCapability.TEXT_TO_TEXT],
+        parameters: {},
+        pricing: { inputCost: 0, outputCost: 0, currency: 'USD' },
+      }));
+    }
+    return [];
+  }
+
+  async getModel(modelId: string): Promise<any> {
+    return this.createTextToTextModel(modelId);
+  }
+
+  async getHealth() {
+    const status = await this.getServiceStatus();
+    return {
+      status: status.healthy ? 'healthy' as const : 'unhealthy' as const,
+      uptime: process.uptime(),
+      activeJobs: 0,
+      queuedJobs: 0,
+    };
+  }
+
+  async configure(config: ProviderConfig): Promise<void> {
+    // No special configuration for now
+    if (config.baseUrl) {
+      this.apiClient = new OllamaAPIClient({ baseUrl: config.baseUrl });
+    }
+  }
+}
+
+import { ProviderRegistry } from '../../../registry/ProviderRegistry';
+ProviderRegistry.getInstance().register('ollama', OllamaDockerProvider);

--- a/src/media/providers/docker/ollama/OllamaTextToTextModel.ts
+++ b/src/media/providers/docker/ollama/OllamaTextToTextModel.ts
@@ -1,0 +1,62 @@
+import { TextToTextModel, TextToTextOptions } from '../../../models/abstracts/TextToTextModel';
+import { ModelMetadata } from '../../../models/abstracts/Model';
+import { Text, TextRole } from '../../../assets/roles';
+import { OllamaAPIClient } from './OllamaAPIClient';
+import { createGenerationPrompt } from '../../../utils/GenerationPromptHelper';
+
+export interface OllamaTextToTextConfig {
+  apiClient: OllamaAPIClient;
+  modelId: string;
+  metadata?: Partial<ModelMetadata>;
+}
+
+export class OllamaTextToTextModel extends TextToTextModel {
+  private apiClient: OllamaAPIClient;
+  private modelId: string;
+
+  constructor(config: OllamaTextToTextConfig) {
+    const metadata: ModelMetadata = {
+      id: config.modelId,
+      name: config.metadata?.name || `Ollama ${config.modelId}`,
+      description: config.metadata?.description || `Ollama text model: ${config.modelId}`,
+      version: config.metadata?.version || '1.0.0',
+      provider: 'ollama',
+      capabilities: ['text-generation'],
+      inputTypes: ['text'],
+      outputTypes: ['text'],
+      ...config.metadata,
+    };
+    super(metadata);
+    this.apiClient = config.apiClient;
+    this.modelId = config.modelId;
+  }
+
+  async transform(input: TextRole | TextRole[], options?: TextToTextOptions): Promise<Text> {
+    const start = Date.now();
+    const role = Array.isArray(input) ? input[0] : input;
+    const text = await role.asText();
+    if (!text.isValid()) {
+      throw new Error('Invalid text input');
+    }
+    const result = await this.apiClient.generateText({ model: this.modelId, prompt: text.content });
+    const processingTime = Date.now() - start;
+    return new Text(result.response, text.language || 'auto', 1.0, {
+      processingTime,
+      model: this.modelId,
+      provider: 'ollama',
+      generation_prompt: createGenerationPrompt({
+        input,
+        options,
+        modelId: this.modelId,
+        modelName: this.modelId,
+        provider: 'ollama',
+        transformationType: 'text-to-text',
+        processingTime,
+      }),
+    }, text.sourceAsset);
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return this.apiClient.testConnection();
+  }
+}

--- a/src/media/providers/docker/ollama/index.ts
+++ b/src/media/providers/docker/ollama/index.ts
@@ -1,0 +1,4 @@
+export { OllamaDockerProvider } from './OllamaDockerProvider';
+export { OllamaTextToTextModel } from './OllamaTextToTextModel';
+export { OllamaAPIClient } from './OllamaAPIClient';
+export type { OllamaConfig, OllamaGenerateRequest, OllamaGenerateResponse } from './OllamaAPIClient';

--- a/src/media/providers/index.ts
+++ b/src/media/providers/index.ts
@@ -21,3 +21,4 @@ export * from './together';
 export * from './docker/chatterbox';
 export * from './docker/whisper';
 export * from './docker/ffmpeg';
+export * from './docker/ollama';

--- a/src/media/registry/bootstrap.ts
+++ b/src/media/registry/bootstrap.ts
@@ -37,6 +37,7 @@ export async function initializeProviders(): Promise<void> {
     () => import('../providers/docker/ffmpeg/FFMPEGDockerProvider'),
     () => import('../providers/docker/chatterbox/ChatterboxDockerProvider'),
     () => import('../providers/docker/whisper/WhisperDockerProvider'),
+    () => import('../providers/docker/ollama/OllamaDockerProvider'),
   ];
   
   // Import all providers concurrently

--- a/src/media/services/OllamaDockerService.ts
+++ b/src/media/services/OllamaDockerService.ts
@@ -1,0 +1,115 @@
+import { DockerComposeService, DockerComposeConfig } from '../../services/DockerComposeService';
+
+export interface OllamaDockerConfig {
+  baseUrl?: string;
+  serviceName?: string;
+  composeFile?: string;
+  containerName?: string;
+  healthCheckUrl?: string;
+  workingDirectory?: string;
+}
+
+export interface ServiceStatus {
+  running: boolean;
+  health: 'healthy' | 'unhealthy' | 'starting' | 'none';
+  state: string;
+  containerId?: string;
+}
+
+export class OllamaDockerService {
+  private dockerService: DockerComposeService;
+  private config: OllamaDockerConfig;
+
+  constructor(config: OllamaDockerConfig = {}) {
+    this.config = {
+      baseUrl: config.baseUrl || 'http://localhost:11434',
+      serviceName: config.serviceName || 'ollama',
+      composeFile: config.composeFile || 'services/ollama/docker-compose.yml',
+      containerName: config.containerName || 'ollama-service',
+      healthCheckUrl: config.healthCheckUrl || 'http://localhost:11434/api/tags',
+      workingDirectory: config.workingDirectory || process.cwd(),
+    };
+
+    const dockerConfig: DockerComposeConfig = {
+      composeFile: this.config.composeFile!,
+      serviceName: this.config.serviceName!,
+      containerName: this.config.containerName!,
+      healthCheckUrl: this.config.healthCheckUrl!,
+      workingDirectory: this.config.workingDirectory!,
+    };
+
+    this.dockerService = new DockerComposeService(dockerConfig);
+  }
+
+  async startService(): Promise<boolean> {
+    try {
+      return await this.dockerService.startService();
+    } catch (error) {
+      console.error('[OllamaDockerService] Failed to start service:', error);
+      return false;
+    }
+  }
+
+  async stopService(): Promise<boolean> {
+    try {
+      return await this.dockerService.stopService();
+    } catch (error) {
+      console.error('[OllamaDockerService] Failed to stop service:', error);
+      return false;
+    }
+  }
+
+  async getServiceStatus(): Promise<ServiceStatus> {
+    try {
+      const status = await this.dockerService.getServiceStatus();
+      return {
+        running: status.running,
+        health: (status.health as ServiceStatus['health']) || 'none',
+        state: status.state || 'unknown',
+        containerId: status.containerName,
+      };
+    } catch (error) {
+      console.error('[OllamaDockerService] Failed to get service status:', error);
+      return { running: false, health: 'unhealthy', state: 'error' };
+    }
+  }
+
+  async waitForHealthy(timeoutMs: number = 60000): Promise<boolean> {
+    try {
+      return await this.dockerService.waitForHealthy(timeoutMs);
+    } catch (error) {
+      console.error('[OllamaDockerService] Service health check failed:', error);
+      return false;
+    }
+  }
+
+  isRunning(): Promise<boolean> {
+    return this.getServiceStatus().then(status => status.running).catch(() => false);
+  }
+
+  isHealthy(): Promise<boolean> {
+    return this.getServiceStatus().then(status => status.running && status.health === 'healthy').catch(() => false);
+  }
+
+  getConfig(): OllamaDockerConfig {
+    return { ...this.config };
+  }
+
+  getDockerServiceInfo() {
+    const dockerConfig = this.dockerService.getConfig();
+    return {
+      containerName: dockerConfig.containerName,
+      dockerImage: 'ollama/ollama:latest',
+      ports: [11434],
+      composeService: dockerConfig.serviceName,
+      composeFile: dockerConfig.composeFile,
+      healthCheckUrl: dockerConfig.healthCheckUrl || `${this.config.baseUrl}/api/tags`,
+      network: 'ollama-network',
+      serviceDirectory: 'services/ollama',
+    };
+  }
+
+  getDockerComposeService(): DockerComposeService {
+    return this.dockerService;
+  }
+}


### PR DESCRIPTION
## Summary
- introduce Ollama docker compose service
- create OllamaDockerService for service management
- implement Ollama API client, model, and provider
- register new provider and export model

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859d846babc832fa4850b909a6a03da