### PR TITLE
Add ElevenLabs provider

### DIFF
--- a/src/media/providers/elevenlabs/ElevenLabsClient.ts
+++ b/src/media/providers/elevenlabs/ElevenLabsClient.ts
@@ -1,0 +1,50 @@
+import axios, { AxiosInstance } from 'axios';
+
+export interface ElevenLabsConfig {
+  apiKey: string;
+  baseUrl?: string;
+  timeout?: number;
+}
+
+export interface ElevenLabsVoice {
+  voice_id: string;
+  name: string;
+  labels?: Record<string, string>;
+}
+
+export class ElevenLabsClient {
+  private client: AxiosInstance;
+
+  constructor(private config: ElevenLabsConfig) {
+    this.client = axios.create({
+      baseURL: config.baseUrl || 'https://api.elevenlabs.io/v1',
+      timeout: config.timeout || 60000,
+      headers: {
+        'xi-api-key': config.apiKey,
+        'Content-Type': 'application/json'
+      }
+    });
+  }
+
+  async testConnection(): Promise<boolean> {
+    try {
+      await this.client.get('/voices');
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async getVoices(): Promise<ElevenLabsVoice[]> {
+    const res = await this.client.get('/voices');
+    return res.data.voices as ElevenLabsVoice[];
+  }
+
+  async generateSpeech(voiceId: string, text: string, options?: { model_id?: string; voice_settings?: Record<string, any> }): Promise<Buffer> {
+    const body: any = { text };
+    if (options?.model_id) body.model_id = options.model_id;
+    if (options?.voice_settings) body.voice_settings = options.voice_settings;
+    const res = await this.client.post(`/text-to-speech/${voiceId}/stream`, body, { responseType: 'arraybuffer' });
+    return Buffer.from(res.data);
+  }
+}

--- a/src/media/providers/elevenlabs/ElevenLabsProvider.ts
+++ b/src/media/providers/elevenlabs/ElevenLabsProvider.ts
@@ -1,0 +1,109 @@
+import {
+  MediaProvider,
+  ProviderType,
+  MediaCapability,
+  ProviderModel,
+  ProviderConfig
+} from '../../types/provider';
+import { TextToAudioProvider } from '../../capabilities';
+import { ElevenLabsTextToAudioModel } from './ElevenLabsTextToAudioModel';
+import { ProviderRegistry } from '../../registry/ProviderRegistry';
+import { ElevenLabsClient, ElevenLabsConfig } from './ElevenLabsClient';
+
+export class ElevenLabsProvider implements MediaProvider, TextToAudioProvider {
+  readonly id = 'elevenlabs';
+  readonly name = 'ElevenLabs';
+  readonly type = ProviderType.REMOTE;
+  readonly capabilities = [MediaCapability.TEXT_TO_AUDIO];
+
+  private config?: ProviderConfig;
+  private apiClient?: ElevenLabsClient;
+  private discoveredModels = new Map<string, ProviderModel>();
+  private configurationPromise: Promise<void> | null = null;
+
+  constructor() {
+    this.configurationPromise = this.autoConfigureFromEnv().catch(() => {
+      this.configurationPromise = null;
+    });
+  }
+
+  get models(): ProviderModel[] {
+    return Array.from(this.discoveredModels.values());
+  }
+
+  private async autoConfigureFromEnv(): Promise<void> {
+    const apiKey = process.env.ELEVENLABS_API_KEY;
+    if (apiKey) {
+      await this.configure({ apiKey });
+    } else {
+      throw new Error('No ELEVENLABS_API_KEY found in environment');
+    }
+  }
+
+  async configure(config: ProviderConfig): Promise<void> {
+    this.config = config;
+    if (!config.apiKey) throw new Error('ElevenLabs API key is required');
+
+    const clientConfig: ElevenLabsConfig = {
+      apiKey: config.apiKey,
+      baseUrl: config.baseUrl,
+      timeout: config.timeout
+    };
+    this.apiClient = new ElevenLabsClient(clientConfig);
+
+    await this.discoverModels();
+  }
+
+  async isAvailable(): Promise<boolean> {
+    if (!this.apiClient) return false;
+    return this.apiClient.testConnection();
+  }
+
+  getModelsForCapability(capability: MediaCapability): ProviderModel[] {
+    if (capability === MediaCapability.TEXT_TO_AUDIO) return this.models;
+    return [];
+  }
+
+  async getModel(modelId: string): Promise<any> {
+    await this.ensureConfigured();
+    if (!this.apiClient) throw new Error('Provider not configured');
+    return new ElevenLabsTextToAudioModel({ apiClient: this.apiClient, voiceId: modelId });
+  }
+
+  async getHealth() {
+    const available = await this.isAvailable();
+    return {
+      status: available ? 'healthy' as const : 'unhealthy' as const,
+      uptime: process.uptime(),
+      activeJobs: 0,
+      queuedJobs: 0
+    };
+  }
+
+  private async discoverModels() {
+    if (!this.apiClient) return;
+    try {
+      const voices = await this.apiClient.getVoices();
+      for (const v of voices) {
+        const model: ProviderModel = {
+          id: v.voice_id,
+          name: v.name,
+          description: 'ElevenLabs voice',
+          capabilities: [MediaCapability.TEXT_TO_AUDIO],
+          parameters: { model_id: 'eleven_monolingual_v1' }
+        };
+        this.discoveredModels.set(v.voice_id, model);
+      }
+    } catch (err) {
+      console.warn('ElevenLabs voice discovery failed:', (err as Error).message);
+    }
+  }
+
+  private async ensureConfigured(): Promise<void> {
+    if (this.apiClient) return;
+    if (this.configurationPromise) await this.configurationPromise;
+    if (!this.apiClient) throw new Error('ElevenLabs provider not configured');
+  }
+}
+
+ProviderRegistry.getInstance().register('elevenlabs', ElevenLabsProvider);

--- a/src/media/providers/elevenlabs/ElevenLabsTextToAudioModel.ts
+++ b/src/media/providers/elevenlabs/ElevenLabsTextToAudioModel.ts
@@ -1,0 +1,94 @@
+import { TextToAudioModel, TextToAudioOptions } from '../../models/abstracts/TextToAudioModel';
+import { ModelMetadata } from '../../models/abstracts/Model';
+import { Audio, TextRole } from '../../assets/roles';
+import { ElevenLabsClient } from './ElevenLabsClient';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { createGenerationPrompt } from '../../utils/GenerationPromptHelper';
+
+export interface ElevenLabsTTSOptions extends TextToAudioOptions {
+  voice?: string;
+  model_id?: string;
+  voice_settings?: Record<string, any>;
+}
+
+export interface ElevenLabsTTSConfig {
+  apiClient: ElevenLabsClient;
+  voiceId: string;
+  modelId?: string;
+  metadata?: Partial<ModelMetadata>;
+}
+
+export class ElevenLabsTextToAudioModel extends TextToAudioModel {
+  private apiClient: ElevenLabsClient;
+  private voiceId: string;
+  private modelId?: string;
+
+  constructor(config: ElevenLabsTTSConfig) {
+    const metadata: ModelMetadata = {
+      id: config.voiceId,
+      name: config.metadata?.name || `ElevenLabs Voice ${config.voiceId}`,
+      description: config.metadata?.description || 'ElevenLabs text-to-speech voice',
+      version: config.metadata?.version || '1.0.0',
+      provider: 'elevenlabs',
+      capabilities: ['text-to-audio', 'text-to-speech'],
+      inputTypes: ['text'],
+      outputTypes: ['audio'],
+      ...config.metadata
+    };
+    super(metadata);
+    this.apiClient = config.apiClient;
+    this.voiceId = config.voiceId;
+    this.modelId = config.modelId;
+  }
+
+  async transform(input: TextRole | TextRole[], options?: ElevenLabsTTSOptions): Promise<Audio> {
+    const role = Array.isArray(input) ? input[0] : input;
+    const text = await role.asText();
+    if (!text.isValid()) throw new Error('Invalid text');
+
+    const voiceId = options?.voice || this.voiceId;
+    const model_id = options?.model_id || this.modelId;
+
+    const audioBuffer = await this.apiClient.generateSpeech(voiceId, text.content, { model_id, voice_settings: options?.voice_settings });
+
+    const tempDir = os.tmpdir();
+    const fileName = `elevenlabs_${Date.now()}_${Math.random().toString(36).substring(2)}.mp3`;
+    const filePath = path.join(tempDir, fileName);
+    fs.writeFileSync(filePath, audioBuffer);
+
+    const result = new Audio(filePath, 'mp3' as any, 1.0, {
+      generation_prompt: createGenerationPrompt({
+        input,
+        options,
+        modelId: voiceId,
+        modelName: voiceId,
+        provider: 'elevenlabs',
+        transformationType: 'text-to-audio'
+      })
+    }, role.sourceAsset);
+    return result;
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return this.apiClient.testConnection();
+  }
+
+  getSupportedFormats(): string[] {
+    return ['mp3'];
+  }
+
+  async getAvailableVoices(): Promise<string[]> {
+    const voices = await this.apiClient.getVoices();
+    return voices.map(v => v.name);
+  }
+
+  supportsVoiceCloning(): boolean {
+    return false;
+  }
+
+  getMaxTextLength(): number {
+    return 10000;
+  }
+}

--- a/src/media/providers/elevenlabs/index.ts
+++ b/src/media/providers/elevenlabs/index.ts
@@ -1,0 +1,10 @@
+/**
+ * ElevenLabs Provider Package
+ *
+ * Exports the ElevenLabs provider, models and API client.
+ */
+
+export { ElevenLabsProvider } from './ElevenLabsProvider';
+export { ElevenLabsTextToAudioModel } from './ElevenLabsTextToAudioModel';
+export { ElevenLabsClient } from './ElevenLabsClient';
+export type { ElevenLabsConfig } from './ElevenLabsClient';

--- a/src/media/providers/index.ts
+++ b/src/media/providers/index.ts
@@ -17,6 +17,9 @@ export * from './openai';
 // fal.ai Provider Package
 export * from './falai';
 
+// ElevenLabs Provider Package
+export * from './elevenlabs';
+
 // Replicate Provider Package
 export * from './replicate';
 

--- a/src/media/registry/bootstrap.ts
+++ b/src/media/registry/bootstrap.ts
@@ -33,6 +33,7 @@ export async function initializeProviders(): Promise<void> {
     () => import('../providers/replicate/ReplicateProvider'),
     () => import('../providers/openrouter/OpenRouterProvider'),
     () => import('../providers/openai/OpenAIProvider'),
+    () => import('../providers/elevenlabs/ElevenLabsProvider'),
     () => import('../providers/anthropic/AnthropicProvider'),
     () => import('../providers/docker/ffmpeg/FFMPEGDockerProvider'),
     () => import('../providers/docker/chatterbox/ChatterboxDockerProvider'),


### PR DESCRIPTION
## Summary
- implement ElevenLabs client and text-to-speech model
- create ElevenLabsProvider with voice discovery
- register provider in bootstrap and export in index

## Testing
- `npm run lint` *(fails: Failed to install required TypeScript dependencies)*
- `npm run type-check` *(fails with missing node type declarations)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a40614d04832fa7179ddf669b2bbc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced ElevenLabs as a new text-to-speech provider, enabling text-to-audio conversion using ElevenLabs voices.
  - Added support for discovering and selecting available ElevenLabs voice models.
  - Users can now generate MP3 audio files from text using ElevenLabs voices.
  - ElevenLabs provider can be configured automatically via environment variables or manually.

- **Chores**
  - Integrated ElevenLabs provider into the platform’s provider registry and initialization process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->