### PR TITLE
Add Creatify provider support

### DIFF
--- a/src/media/providers/creatify/CreatifyClient.ts
+++ b/src/media/providers/creatify/CreatifyClient.ts
@@ -1,0 +1,32 @@
+import { Creatify, CreatifyApiOptions } from '@tsavo/creatify-api-ts';
+
+export interface CreatifyConfig {
+  apiId: string;
+  apiKey: string;
+  baseUrl?: string;
+}
+
+export class CreatifyClient {
+  private client: Creatify;
+  constructor(config: CreatifyConfig) {
+    const options: CreatifyApiOptions = {
+      apiId: config.apiId,
+      apiKey: config.apiKey,
+    } as CreatifyApiOptions;
+    if (config.baseUrl) options.baseUrl = config.baseUrl;
+    this.client = new Creatify(options);
+  }
+
+  get api() {
+    return this.client;
+  }
+
+  async testConnection(): Promise<boolean> {
+    try {
+      await this.client.avatar.getAvatars();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/media/providers/creatify/CreatifyProvider.ts
+++ b/src/media/providers/creatify/CreatifyProvider.ts
@@ -1,0 +1,128 @@
+import {
+  MediaProvider,
+  ProviderType,
+  MediaCapability,
+  ProviderModel,
+  ProviderConfig,
+  GenerationRequest,
+  GenerationResult
+} from '../../types/provider';
+import { TextToVideoProvider, TextToAudioProvider } from '../../capabilities';
+import { TextToVideoModel } from '../../models/abstracts/TextToVideoModel';
+import { TextToAudioModel } from '../../models/abstracts/TextToAudioModel';
+import { CreatifyClient, CreatifyConfig } from './CreatifyClient';
+import { CreatifyTextToVideoModel } from './CreatifyTextToVideoModel';
+import { CreatifyTextToAudioModel } from './CreatifyTextToAudioModel';
+
+export class CreatifyProvider implements MediaProvider, TextToVideoProvider, TextToAudioProvider {
+  readonly id = 'creatify';
+  readonly name = 'Creatify';
+  readonly type = ProviderType.REMOTE;
+  readonly capabilities = [MediaCapability.TEXT_TO_VIDEO, MediaCapability.TEXT_TO_AUDIO];
+
+  private config?: ProviderConfig & { apiId?: string };
+  private client?: CreatifyClient;
+
+  get models(): ProviderModel[] {
+    return [
+      {
+        id: 'avatar-lipsync',
+        name: 'Creatify Avatar Lipsync',
+        description: 'Generate avatar videos from text',
+        capabilities: [MediaCapability.TEXT_TO_VIDEO],
+        parameters: {
+          text: { type: 'string' },
+          avatarId: { type: 'string' },
+          voiceId: { type: 'string' },
+          aspect_ratio: { type: 'string', default: '16:9' }
+        }
+      },
+      {
+        id: 'creatify-tts',
+        name: 'Creatify TTS',
+        description: 'Text to speech via Creatify',
+        capabilities: [MediaCapability.TEXT_TO_AUDIO],
+        parameters: {
+          text: { type: 'string' },
+          voiceId: { type: 'string' }
+        }
+      }
+    ];
+  }
+
+  async configure(config: ProviderConfig & { apiId?: string }): Promise<void> {
+    this.config = config;
+    const apiId = config.apiId || config.environment?.CREATIFY_API_ID || process.env.CREATIFY_API_ID;
+    const apiKey = config.apiKey || process.env.CREATIFY_API_KEY;
+    if (!apiId || !apiKey) {
+      throw new Error('Creatify API credentials are required');
+    }
+    const clientConfig: CreatifyConfig = { apiId, apiKey, baseUrl: config.baseUrl };
+    this.client = new CreatifyClient(clientConfig);
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return this.client ? this.client.testConnection() : false;
+  }
+
+  getModelsForCapability(capability: MediaCapability): ProviderModel[] {
+    return this.models.filter(m => m.capabilities.includes(capability));
+  }
+
+  async createTextToVideoModel(modelId: string): Promise<TextToVideoModel> {
+    if (!this.client) throw new Error('Provider not configured');
+    if (modelId !== 'avatar-lipsync') throw new Error(`Unsupported model ${modelId}`);
+    return new CreatifyTextToVideoModel({
+      client: this.client,
+      defaultVoiceId: process.env.CREATIFY_ACCENT
+    });
+  }
+  getSupportedTextToVideoModels(): string[] { return ['avatar-lipsync']; }
+  supportsTextToVideoModel(modelId: string): boolean { return modelId === 'avatar-lipsync'; }
+
+  async createTextToAudioModel(modelId: string): Promise<TextToAudioModel> {
+    if (!this.client) throw new Error('Provider not configured');
+    if (modelId !== 'creatify-tts') throw new Error(`Unsupported model ${modelId}`);
+    return new CreatifyTextToAudioModel({
+      client: this.client,
+      defaultVoiceId: process.env.CREATIFY_ACCENT
+    });
+  }
+  getSupportedTextToAudioModels(): string[] { return ['creatify-tts']; }
+  supportsTextToAudioModel(modelId: string): boolean { return modelId === 'creatify-tts'; }
+
+  async startService(): Promise<void> {}
+  async stopService(): Promise<void> {}
+  async getServiceStatus() { return { running: true, healthy: await this.isAvailable(), error: undefined }; }
+
+  async generate(request: GenerationRequest): Promise<GenerationResult> {
+    throw new Error('CreatifyProvider should use Model instances for generation');
+  }
+
+  async getModel(modelId: string): Promise<any> {
+    if (modelId === 'avatar-lipsync') return this.createTextToVideoModel(modelId);
+    if (modelId === 'creatify-tts') return this.createTextToAudioModel(modelId);
+    throw new Error(`Unknown model ${modelId}`);
+  }
+
+  async getHealth() {
+    const healthy = await this.isAvailable();
+    return { status: healthy ? 'healthy' as const : 'unhealthy' as const, uptime: process.uptime(), activeJobs: 0, queuedJobs: 0 };
+  }
+
+  constructor() {
+    this.autoConfigureFromEnv().catch(() => {});
+  }
+
+  private async autoConfigureFromEnv(): Promise<void> {
+    const apiId = process.env.CREATIFY_API_ID;
+    const apiKey = process.env.CREATIFY_API_KEY;
+    if (apiId && apiKey) {
+      await this.configure({ apiId, apiKey });
+    }
+  }
+}
+
+import { ProviderRegistry } from '../../registry/ProviderRegistry';
+ProviderRegistry.getInstance().register('creatify', CreatifyProvider);
+export default CreatifyProvider;

--- a/src/media/providers/creatify/CreatifyTextToAudioModel.ts
+++ b/src/media/providers/creatify/CreatifyTextToAudioModel.ts
@@ -1,0 +1,94 @@
+import { TextToAudioModel, TextToAudioOptions } from '../../models/abstracts/TextToAudioModel';
+import { ModelMetadata } from '../../models/abstracts/Model';
+import { TextRole, Audio } from '../../assets/roles';
+import { SmartAssetFactory } from '../../assets/SmartAssetFactory';
+import { CreatifyClient } from './CreatifyClient';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import fetch from 'node-fetch';
+
+export interface CreatifyTextToAudioOptions extends TextToAudioOptions {
+  voiceId?: string;
+}
+
+export interface CreatifyTextToAudioConfig {
+  client: CreatifyClient;
+  defaultVoiceId?: string;
+}
+
+export class CreatifyTextToAudioModel extends TextToAudioModel {
+  private client: CreatifyClient;
+  private defaultVoiceId?: string;
+
+  constructor(config: CreatifyTextToAudioConfig) {
+    const metadata: ModelMetadata = {
+      id: 'creatify-tts',
+      name: 'Creatify Text To Speech',
+      description: 'Creatify text-to-speech model',
+      version: '1.0.0',
+      provider: 'creatify',
+      capabilities: ['text-to-audio'],
+      inputTypes: ['text'],
+      outputTypes: ['audio']
+    };
+    super(metadata);
+    this.client = config.client;
+    this.defaultVoiceId = config.defaultVoiceId;
+  }
+
+  async transform(input: TextRole | TextRole[], options?: CreatifyTextToAudioOptions): Promise<Audio> {
+    const role = Array.isArray(input) ? input[0] : input;
+    const text = await role.asText();
+    if (!text.isValid()) throw new Error('Invalid text input');
+    const voiceId = options?.voiceId || this.defaultVoiceId;
+    if (!voiceId) throw new Error('voiceId is required');
+
+    const result = await this.client.api.textToSpeech.createAndWaitForTextToSpeech({
+      script: text.content,
+      accent: voiceId
+    });
+    if (!result.output) {
+      throw new Error('Creatify returned no audio URL');
+    }
+
+    const buffer = await this.downloadFile(result.output);
+    const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'creatify-audio-'));
+    const filePath = path.join(dir, 'speech.mp3');
+    fs.writeFileSync(filePath, buffer);
+
+    const asset = await SmartAssetFactory.load(filePath);
+    const audio = await (asset as any).asAudio();
+    if (audio.metadata) {
+      Object.assign(audio.metadata, { url: result.output, provider: 'creatify' });
+    }
+    return audio;
+  }
+
+  private async downloadFile(url: string): Promise<Buffer> {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`Failed to download ${url}: ${res.statusText}`);
+    return Buffer.from(await res.arrayBuffer());
+  }
+
+  async isAvailable() {
+    return this.client.testConnection();
+  }
+
+  getSupportedFormats(): string[] {
+    return ['mp3'];
+  }
+
+  async getAvailableVoices(): Promise<string[]> {
+    const voices = await this.client.api.avatar.getVoices();
+    return voices.map(v => v.id);
+  }
+
+  supportsVoiceCloning(): boolean {
+    return false;
+  }
+
+  getMaxTextLength(): number {
+    return 2000;
+  }
+}

--- a/src/media/providers/creatify/CreatifyTextToVideoModel.ts
+++ b/src/media/providers/creatify/CreatifyTextToVideoModel.ts
@@ -1,0 +1,109 @@
+import { TextToVideoModel, TextToVideoOptions } from '../../models/abstracts/TextToVideoModel';
+import { ModelMetadata } from '../../models/abstracts/Model';
+import { TextRole, Video } from '../../assets/roles';
+import { SmartAssetFactory } from '../../assets/SmartAssetFactory';
+import { CreatifyClient } from './CreatifyClient';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import fetch from 'node-fetch';
+
+export interface CreatifyTextToVideoOptions extends TextToVideoOptions {
+  avatarId?: string;
+  voiceId?: string;
+}
+
+export interface CreatifyTextToVideoConfig {
+  client: CreatifyClient;
+  defaultAvatarId?: string;
+  defaultVoiceId?: string;
+}
+
+export class CreatifyTextToVideoModel extends TextToVideoModel {
+  private client: CreatifyClient;
+  private defaultAvatarId?: string;
+  private defaultVoiceId?: string;
+
+  constructor(config: CreatifyTextToVideoConfig) {
+    const metadata: ModelMetadata = {
+      id: 'avatar-lipsync',
+      name: 'Creatify Avatar Lipsync',
+      description: 'Generate avatar videos using Creatify',
+      version: '1.0.0',
+      provider: 'creatify',
+      capabilities: ['text-to-video'],
+      inputTypes: ['text'],
+      outputTypes: ['video']
+    };
+    super(metadata);
+    this.client = config.client;
+    this.defaultAvatarId = config.defaultAvatarId;
+    this.defaultVoiceId = config.defaultVoiceId;
+  }
+
+  async transform(input: TextRole | TextRole[], options?: CreatifyTextToVideoOptions): Promise<Video> {
+    const role = Array.isArray(input) ? input[0] : input;
+    const text = await role.asText();
+    if (!text.isValid()) {
+      throw new Error('Invalid text input');
+    }
+
+    const avatarId = options?.avatarId || this.defaultAvatarId;
+    const voiceId = options?.voiceId || this.defaultVoiceId;
+    if (!avatarId || !voiceId) {
+      throw new Error('avatarId and voiceId are required');
+    }
+
+    const result = await this.client.api.avatar.createAndWaitForLipsync({
+      text: text.content,
+      creator: avatarId,
+      aspect_ratio: (options?.aspectRatio as any) || '16:9',
+      accent: voiceId
+    });
+
+    if (!result.output) {
+      throw new Error('Creatify returned no video URL');
+    }
+
+    const buffer = await this.downloadFile(result.output);
+    const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'creatify-video-'));
+    const filePath = path.join(dir, 'video.mp4');
+    fs.writeFileSync(filePath, buffer);
+
+    const asset = await SmartAssetFactory.load(filePath);
+    const video = await (asset as any).asVideo();
+    if (video.metadata) {
+      Object.assign(video.metadata, {
+        url: result.output,
+        provider: 'creatify'
+      });
+    }
+    return video;
+  }
+
+  private async downloadFile(url: string): Promise<Buffer> {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`Failed to download ${url}: ${res.statusText}`);
+    return Buffer.from(await res.arrayBuffer());
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return this.client.testConnection();
+  }
+
+  getSupportedFormats(): string[] {
+    return ['mp4'];
+  }
+
+  getSupportedAspectRatios(): string[] {
+    return ['16:9', '9:16', '1:1'];
+  }
+
+  getSupportedDurationRange() {
+    return { min: 1, max: 120 };
+  }
+
+  getMaxResolution() {
+    return { width: 1920, height: 1080 };
+  }
+}

--- a/src/media/providers/creatify/index.ts
+++ b/src/media/providers/creatify/index.ts
@@ -1,0 +1,5 @@
+export { CreatifyProvider } from './CreatifyProvider';
+export { CreatifyTextToVideoModel } from './CreatifyTextToVideoModel';
+export { CreatifyTextToAudioModel } from './CreatifyTextToAudioModel';
+export { CreatifyClient } from './CreatifyClient';
+export type { CreatifyConfig } from './CreatifyClient';

--- a/src/media/providers/index.ts
+++ b/src/media/providers/index.ts
@@ -35,6 +35,9 @@ export * from './xai';
 // Mistral AI Provider Package
 export * from './mistral';
 
+// Creatify Provider Package
+export * from './creatify';
+
 // Azure OpenAI Provider Package
 export * from './azure';
 


### PR DESCRIPTION
## Summary
- add new Creatify provider with text-to-video and text-to-audio models
- implement Creatify client wrapper
- export Creatify provider package

## Testing
- `npx vitest run` *(fails: needs to install vitest)*

------
https://chatgpt.com/codex/tasks/task_e_685a44e8f374832fa4942e27d48c7feb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for Creatify as a new media provider, enabling text-to-video and text-to-audio generation capabilities.
  - Added options to generate avatar-driven videos and speech audio using Creatify's API, with configurable voices and avatars.
  - Users can now select from supported formats, aspect ratios, and voices for generated content.
  - Health status and model availability checks are now available for the Creatify provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->